### PR TITLE
Fix .travis.yml to properly build the solution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: csharp
-solution: CSAPlatform.sln
+solution: CSAPlatform/CSAPlatform.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: csharp
-solution: CSAPlatform/CSAPlatform.sln
 mono: none
 dotnet: 6.0.401
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,7 @@
 language: csharp
 solution: CSAPlatform/CSAPlatform.sln
+mono: none
+dotnet: 6.0.401
+script:
+ - dotnet restore
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,2 @@
 language: csharp
 solution: CSAPlatform.sln
-script:
- - dotnet restore
- - dotnet test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: csharp
 mono: none
-dotnet: 6.0.401
+addons:
+ snaps:
+  - name: dotnet-sdk 
+  - confinement: classic
+  - channel: 6.0/beta
 script:
  - dotnet restore
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: csharp
 mono: none
+solution: CSAPlatform/CSAPlatform.sln
 addons:
  snaps:
   - name: dotnet-sdk 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ mono: none
 addons:
  snaps:
   - name: dotnet-sdk 
-  - confinement: classic
-  - channel: 6.0/beta
+    confinement: classic
+    channel: 6.0/beta
 script:
  - dotnet restore
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: csharp
 mono: none
-solution: CSAPlatform/CSAPlatform.sln
 addons:
  snaps:
   - name: dotnet-sdk 
     confinement: classic
     channel: 6.0/beta
 script:
- - dotnet restore
+ - dotnet build ./CSAPlatform/CSAPlatform.sln
  


### PR DESCRIPTION
TravisCI defaults to build the project against Mono, but the SDK we are using has yet to be included in the repository Mono installs from. As such, the build would always fail. The .travis.yml file has been fixed in this pull request and now manually installs the proper .NET Core SDK and also builds the solution against .NET Core instead of Mono.